### PR TITLE
Compatibility with ZF3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
-    - php: 5.4
     - php: 5.5
     - php: 5.6
     - php: 7

--- a/composer.json
+++ b/composer.json
@@ -19,22 +19,23 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5 || ^7.0",
         "maximebf/debugbar": "1.*",
-        "zendframework/zend-mvc": "*",
-        "zendframework/zend-log": "*",
-        "zendframework/zend-servicemanager": "*",
-        "zendframework/zend-view": "*",
-        "zendframework/zend-eventmanager": "*",
-        "zendframework/zend-http": "*",
-        "zendframework/zend-modulemanager": "*"
+        "zendframework/zend-mvc": "2.* || ^3.0",
+        "zendframework/zend-log": "2.*",
+        "zendframework/zend-servicemanager": "~2.6 || ^3.0",
+        "zendframework/zend-view": "2.*",
+        "zendframework/zend-eventmanager": "2.* || ^3.0",
+        "zendframework/zend-http": "2.*",
+        "zendframework/zend-modulemanager": "2.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "zendframework/zend-test": "*",
-        "zendframework/zend-config": "*",
-        "zendframework/zend-serializer": "*",
-        "zendframework/zend-i18n": "*"
+        "zendframework/zend-test": "2.* || ^3.0",
+        "zendframework/zend-config": "2.*",
+        "zendframework/zend-serializer": "2.*",
+        "zendframework/zend-i18n": "2.*",
+        "zendframework/zend-db": "2.*"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -21,20 +21,20 @@
     "require": {
         "php": ">=5.3.3",
         "maximebf/debugbar": "1.*",
-        "zendframework/zend-mvc": "2.*",
-        "zendframework/zend-log": "2.*",
-        "zendframework/zend-servicemanager": "2.*",
-        "zendframework/zend-view": "2.*",
-        "zendframework/zend-eventmanager": "2.*",
-        "zendframework/zend-http": "2.*",
-        "zendframework/zend-modulemanager": "2.*"
+        "zendframework/zend-mvc": "*",
+        "zendframework/zend-log": "*",
+        "zendframework/zend-servicemanager": "*",
+        "zendframework/zend-view": "*",
+        "zendframework/zend-eventmanager": "*",
+        "zendframework/zend-http": "*",
+        "zendframework/zend-modulemanager": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "zendframework/zend-test": "2.*",
-        "zendframework/zend-config": "2.*",
-        "zendframework/zend-serializer": "2.*",
-        "zendframework/zend-i18n": "2.*"
+        "zendframework/zend-test": "*",
+        "zendframework/zend-config": "*",
+        "zendframework/zend-serializer": "*",
+        "zendframework/zend-i18n": "*"
     },
     "autoload": {
         "psr-0": {

--- a/src/ZfSnapPhpDebugBar/Module.php
+++ b/src/ZfSnapPhpDebugBar/Module.php
@@ -97,7 +97,7 @@ class Module implements Config, Service, Autoloader, ViewHelper, Bootstrap
         $applicationEventManager = $application->getEventManager();
         $viewEventManager = $serviceManager->get('View')->getEventManager();
         $viewRenderer = $serviceManager->get('ViewRenderer');
-        $debugbar = $serviceManager->get('debugbar');
+        $debugbar = $serviceManager->get('DebugBar');
         $timeCollector = $debugbar['time'];
         $exceptionCollector = $debugbar['exceptions'];
         self::$messageCollector = $debugbar['messages'];
@@ -124,7 +124,7 @@ class Module implements Config, Service, Autoloader, ViewHelper, Bootstrap
 
         // Auto enable assets
         if ($debugbarConfig['auto-append-assets']) {
-            $viewRenderer->plugin('DebugBar')->appendAssets();
+            $viewRenderer->plugin('debugbar')->appendAssets();
         }
 
         // Timeline

--- a/src/ZfSnapPhpDebugBar/View/Helper/DebugBarFactory.php
+++ b/src/ZfSnapPhpDebugBar/View/Helper/DebugBarFactory.php
@@ -4,6 +4,7 @@ namespace ZfSnapPhpDebugBar\View\Helper;
 
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Interop\Container\ContainerInterface;
 
 /**
  * DebugBarFactory
@@ -14,23 +15,29 @@ class DebugBarFactory implements FactoryInterface
 {
 
     /**
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return DebugBar
+     * {@inheritdoc}
      */
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $sm = $serviceLocator->getServiceLocator();
         /* @var $debugbar \DebugBar\DebugBar */
-        $debugbar = $sm->get('DebugBar');
+        $debugbar = $container->get('DebugBar');
         $renderer = $debugbar->getJavascriptRenderer();
 
         $renderer->setBaseUrl('/DebugBar/Resources/');
         $renderer->setBasePath('/DebugBar/Resources/');
 
-        $config = $sm->get('Config');
+        $config = $container->get('Config');
         $customStyle = $config['php-debug-bar']['view']['custom-style-path'];
 
         return new DebugBar($renderer, $customStyle);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator->getServiceLocator(), 'ZfSnapPhpDebugBar\View\Helper\DebugBar');
     }
 
 }

--- a/tests/Functional/DebugBarTest.php
+++ b/tests/Functional/DebugBarTest.php
@@ -16,9 +16,9 @@ class DebugBarTest extends AbstractHttpControllerTestCase
         $this->dispatch('/');
 
         $this->assertResponseStatusCode(200);
-        $debugbar = $this->getApplicationServiceLocator()->get('debugbar');
+        $debugbar = $this->getApplicationServiceLocator()->get('DebugBar');
 
-        $this->assertInstanceOf('\DebugBar\DebugBar', $debugbar);
+        $this->assertInstanceOf('DebugBar\DebugBar', $debugbar);
     }
     
     protected function setUp()

--- a/tests/assets/application.config.php
+++ b/tests/assets/application.config.php
@@ -1,9 +1,20 @@
 <?php
 
+$modules = array(
+    'ZfSnapPhpDebugBar',
+);
+$zf3Modules = array(
+    'Zend\Db',
+    'Zend\Router',
+);
+foreach ($zf3Modules as $module) {
+    $dirModule = strtolower(str_replace('\\', '-', $module));
+    if (is_file(__DIR__ . "/../../vendor/zendframework/{$dirModule}/src/Module.php")) {
+        array_unshift($modules, $module);
+    }
+}
 return array(
-    'modules' => array(
-        'ZfSnapPhpDebugBar',
-    ),
+    'modules' => $modules,
     'module_listener_options' => array(
         'config_glob_paths' => array(
             __DIR__ . '/{global,local}.config.php',

--- a/tests/assets/global.config.php
+++ b/tests/assets/global.config.php
@@ -12,7 +12,7 @@ return array(
     'router' => array(
         'routes' => array(
             'home' => array(
-                'type' => 'Zend\Mvc\Router\Http\Literal',
+                'type' => 'literal',
                 'options' => array(
                     'route' => '/',
                     'defaults' => array(


### PR DESCRIPTION
- Up minimal version of PHP to 5.5.
- Upgrade tests.
- Upgrade factories.
- Small fixes for compatibility.