### PR TITLE
Disable PhpDebugBar when ViewModel is terminate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.5
   - 5.6

--- a/src/Listener/RenderOnShutdownListener.php
+++ b/src/Listener/RenderOnShutdownListener.php
@@ -34,7 +34,7 @@ class RenderOnShutdownListener extends AbstractListenerAggregate
     {
         $response = $event->getResponse();
 
-        if (!$response instanceof Response) {
+        if (!$response instanceof Response || $event->getViewModel()->terminate()) {
             return;
         }
         $contentTypeHeader = $response->getHeaders()->get('Content-type');

--- a/tests/Functional/DebugBarTest.php
+++ b/tests/Functional/DebugBarTest.php
@@ -95,8 +95,19 @@ class DebugBarTest extends AbstractHttpControllerTestCase
         $this->assertResponseHeaderContains('Content-Type', 'text/css; charset=UTF-8');
     }
 
+    public function testPartial()
+    {
+        $this->dispatch('/partial');
+        $this->assertNotResponseContains('var phpdebugbar = new PhpDebugBar.DebugBar();');
+    }
+
     private function assertResponseContains($string)
     {
         $this->assertContains($string, $this->getResponse()->getContent());
+    }
+
+    private function assertNotResponseContains($string)
+    {
+        $this->assertNotContains($string, $this->getResponse()->getContent());
     }
 }

--- a/tests/Functional/DummyController.php
+++ b/tests/Functional/DummyController.php
@@ -22,4 +22,9 @@ class DummyController extends AbstractActionController
     {
         throw new \Exception(self::EXCEPTION_MESSAGE);
     }
+
+    public function partialAction()
+    {
+        return (new ViewModel)->setTemplate('dummy/index')->setTerminal(true);
+    }
 }

--- a/tests/assets/global.config.php
+++ b/tests/assets/global.config.php
@@ -24,6 +24,16 @@ return [
                     ],
                 ],
             ],
+            'home-partial' => [
+                'type' => 'literal',
+                'options' => [
+                    'route' => '/partial',
+                    'defaults' => [
+                        'controller' => ZfSnapPhpDebugBar\Tests\Functional\DummyController::class,
+                        'action' => 'partial',
+                    ],
+                ],
+            ],
             'error' => [
                 'type' => 'literal',
                 'options' => [


### PR DESCRIPTION
PhpDebugBar was injecting always on view. I made ability to disable it when ViewModel is terminate.